### PR TITLE
Ensure work with TLS 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ _ReSharper*/
 packages/*
 !packages/repositories.config
 /HockeyAppForWindows/Constants.cs
+
+.vs/

--- a/HockeyAppForWindows/HockeyAppForWindows.csproj
+++ b/HockeyAppForWindows/HockeyAppForWindows.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HockeyApp.AppLoader</RootNamespace>
     <AssemblyName>HockeyAppForWindows</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/HockeyAppForWindows/HockeyBootstrapper.cs
+++ b/HockeyAppForWindows/HockeyBootstrapper.cs
@@ -17,6 +17,7 @@ using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -37,7 +38,9 @@ namespace HockeyApp.AppLoader
         {
             LogManager.GetLog = type => new NLogLogger(type);
             HockeyApp.HockeyLogManager.GetLog = type => new HockeyAppLogger();
-            
+
+            // Set .Net to use only TLS 1.2 protocol
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         protected override void Configure()

--- a/HockeyAppForWindowsConsole/HockeyAppForWindowsConsole.csproj
+++ b/HockeyAppForWindowsConsole/HockeyAppForWindowsConsole.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HockeyAppForWindows.Hoch</RootNamespace>
     <AssemblyName>Hoch</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>

--- a/HockeyAppForWindowsConsole/Program.cs
+++ b/HockeyAppForWindowsConsole/Program.cs
@@ -13,6 +13,7 @@ using HockeyApp;
 using System.Diagnostics;
 using Microsoft.ApplicationInsights;
 using System.Security.Cryptography;
+using System.Net;
 
 namespace HockeyAppForWindows.Hoch
 {
@@ -35,6 +36,8 @@ namespace HockeyAppForWindows.Hoch
 
         static void Main(string[] args)
         {
+            // Set .Net to use only TLS 1.2 protocol
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
 #if DEBUG
             HockeyApp.HockeyClient.Current.Configure(HockeyApp.AppLoader.DemoConstants.AppId);


### PR DESCRIPTION
Make sure the command line app is able to use TLS 1.2 when uploading to HockeyApp.